### PR TITLE
resolve deadline unix issue

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/PostDiscussionRequest.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/PostDiscussionRequest.kt
@@ -23,5 +23,5 @@ data class PostDiscussionRequest(
 
     val assignees: List<Long>? = null,
 
-    val deadline: Long? = null,
+    val deadline: Long? = null
 )

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/PostDiscussionRequest.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/PostDiscussionRequest.kt
@@ -23,5 +23,5 @@ data class PostDiscussionRequest(
 
     val assignees: List<Long>? = null,
 
-    val deadline: Long = 0
+    val deadline: Long? = null,
 )

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/entity/discussion/DiscussionEntity.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/entity/discussion/DiscussionEntity.kt
@@ -48,7 +48,7 @@ data class DiscussionEntity(
 
     @field:Column(name = "deadline_unix")
     @ColumnDefault("0")
-    val deadlineUnix: Long = 0,
+    val deadlineUnix: Long? = null,
 
     @field:Column(name = "closed_unix")
     val closedUnix: Long? = null,

--- a/src/main/kotlin/swm/virtuoso/reviewservice/domain/Discussion.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/domain/Discussion.kt
@@ -20,7 +20,7 @@ data class Discussion(
 
     var isClosed: Boolean = false,
 
-    var deadlineUnix: Long = 0,
+    var deadlineUnix: Long? = null,
 
     var createdUnix: Long? = null,
 


### PR DESCRIPTION
deadlineUnix가 Long  인경우 데이터베이스 조회 시 문제 발생합니다
(/adapter/out/persistence/DiscussionPersistenceAdapter.kt:findDiscussions() 함수 호출시 문제가 발생합니다)
따라서 nullable long 으로 다시 변환하는 과정을 거쳤습니다