### PR TITLE
fix: DiscussionCommentResponse에 필요한 정보 누락 및 GlobalExceptionHandler의 에…

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
@@ -32,7 +32,7 @@ data class DiscussionCommentResponse(
                 createdUnix = discussionComment.createdUnix,
                 updatedUnix = discussionComment.updatedUnix,
                 codeId = discussionComment.codeId,
-                discussionId = discussionComment.id,
+                discussionId = discussionComment.id
             )
         }
     }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
@@ -6,6 +6,8 @@ import swm.virtuoso.reviewservice.domain.DiscussionReaction
 data class DiscussionCommentResponse(
     val id: Long,
     val posterId: Long,
+    val discussionId: Long,
+    val codeId: Long?,
     val scope: String,
     val startLine: Int?,
     val endLine: Int?,
@@ -28,7 +30,9 @@ data class DiscussionCommentResponse(
                 content = discussionComment.content,
                 reactions = reactions,
                 createdUnix = discussionComment.createdUnix,
-                updatedUnix = discussionComment.updatedUnix
+                updatedUnix = discussionComment.updatedUnix,
+                codeId = discussionComment.codeId,
+                discussionId = discussionComment.id,
             )
         }
     }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/common/exception/GlobalExceptionHandler.kt
@@ -60,7 +60,7 @@ class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException::class)
     fun handlerIllegalArgumentException(exception: IllegalArgumentException): ErrorResponse {
-        return ErrorResponse(HttpStatus.NOT_FOUND, ILLEGAL_ARGUMENT_EXCEPTION, exception.message!!)
+        return ErrorResponse(HttpStatus.BAD_REQUEST, ILLEGAL_ARGUMENT_EXCEPTION, exception.message!!)
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)


### PR DESCRIPTION
한일
---
DiscussionCommentResponse Dto에서 필요한 필드 추가(codeId, DiscussionId)
에러 처리 어노테이션의 status code와 반환되는 status code의 불일치 해결