### PR TITLE
feat: add swagger response annotation

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/common/annotation/SwaggerResponse.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/common/annotation/SwaggerResponse.kt
@@ -1,0 +1,12 @@
+package swm.virtuoso.reviewservice.common.annotation
+
+import kotlin.reflect.KClass
+
+@Repeatable
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SwaggerResponse(
+    val responseStatus: String,
+    val description: String,
+    val responseType: KClass<*> = Void::class
+)

--- a/src/main/kotlin/swm/virtuoso/reviewservice/common/config/SwaggerResponseConfig.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/common/config/SwaggerResponseConfig.kt
@@ -1,0 +1,54 @@
+package swm.virtuoso.reviewservice.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.SpecVersion
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.responses.ApiResponse
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.utils.SpringDocAnnotationsUtils.extractSchema
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
+import swm.virtuoso.reviewservice.common.annotation.SwaggerResponse
+
+@Configuration
+class SwaggerResponseConfig {
+    @Bean
+    fun customGlobalHeaderOpenApiCustomizer(requestMappings: RequestMappingHandlerMapping) = OpenApiCustomizer { openApi ->
+        requestMappings.handlerMethods
+            .filter { (_, handlerMethod) -> handlerMethod.method.getAnnotationsByType(SwaggerResponse::class.java).isNotEmpty() }
+            .forEach { (mappingInfo, handlerMethod) ->
+                // Because I'm lazy person, this implementation only handles first mapping
+                val pattern = mappingInfo.pathPatternsCondition?.patterns?.first()?.patternString
+                val method = mappingInfo.methodsCondition.methods.first().asHttpMethod()
+                val path = openApi.paths.filter { it.key == pattern }.values.first()
+                val operation = when (method) {
+                    HttpMethod.HEAD -> path.head
+                    HttpMethod.GET -> path.get
+                    HttpMethod.POST -> path.post
+                    HttpMethod.PUT -> path.put
+                    HttpMethod.PATCH -> path.patch
+                    HttpMethod.DELETE -> path.delete
+                    HttpMethod.OPTIONS -> path.options
+                    HttpMethod.TRACE -> path.trace
+                    else -> null
+                }
+                operation?.let {
+                    val swaggerResponses = handlerMethod.method.getAnnotationsByType(SwaggerResponse::class.java)
+                    swaggerResponses.forEach {
+                        operation.responses
+                            .addApiResponse(
+                                it.responseStatus,
+                                ApiResponse().apply {
+                                    val schema = extractSchema(Components(), it.responseType.java, null, arrayOf(), SpecVersion.V30)
+                                    description = it.description
+                                    content = Content().addMediaType("*/*", MediaType().schema(schema))
+                                }
+                            )
+                    }
+                }
+            }
+    }
+}


### PR DESCRIPTION
## SwaggerResponse Annotation 기능 추가입니다. 
기존의 ApiResponses 의 보일러 플레이트코드가 너무 길어져 가독성을 해친다 생각해서 작성하게 되었습니다.. 
컨트롤러단 보면 코드가 하나도 안보이고 어노테이션들만 보이기도 하고요ㅠ,ㅠ
현재 Schema(type = "array") 의 경우를 제외하고는 일단 가볍게 지원하는 수준이고 로컬 환경에서는 작동하는것을 확인하였습니다
몇몇 최적화할거리나 추가 구현거리가 존재는 하나 경우를 다 따지는게 많은 효용은 안나올거같기에 일단 뒤로 미루어놓았습니다
몇가지 한계사항으로 springdoc 내부 메서드에 강한 의존성이 존재해 springdoc 에서 가져오는 함수(extractSchema)의 내부 구현이 바뀌면 작동하지 않을수도 있습니다. 검증을 통해 실험적인 단계를 넘어 사용해도 괜찮다 싶으시면 그때 천천히 머지해도 됩니다
### Before SwaggerResponse 
```java
   @ApiResponses(
        value = [
            ApiResponse(
                responseCode = "200",
                description = "코멘트 가져오기 성공",
                content = [Content(schema = Schema(implementation = DiscussionCommentResponse::class))]
            ),

            ApiResponse(
                responseCode = "404",
                description = "해당하는 id를 가진 디스커션 코멘트가 없음.",
                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
            )
        ]
    )
```

### After SwaggerResponse
```java
@SwaggerResponse("200", "코멘트 가져오기 성공", DiscussionCommentResponse::class)
@SwaggerResponse("404", "해당하는 id를 가진 디스커션 코멘트가 없음.", ErrorResponse::class)
```

추가) 린트 에러가 발생하는것을 확인하였으나, 이는 dev 브랜치의 문제로 SwaggerResponse/SwaggerResponseConfig 이외의 린트는 따로 커밋해서 올리지는 않았습니다