### PR TITLE
[VIR-203] Fix: ai 샘플 코드 기능을 위해 DiscussionCommentResponse에 filePath 필드 추가

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionCommentController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionCommentController.kt
@@ -24,6 +24,7 @@ import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ModifyCommentRequ
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.PostCommentRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionCommentResponse
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionCommentUseCase
+import swm.virtuoso.reviewservice.application.port.`in`.DiscussionFileUseCase
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionReactionUseCase
 import swm.virtuoso.reviewservice.common.exception.ErrorResponse
 import swm.virtuoso.reviewservice.domain.DiscussionComment
@@ -35,6 +36,7 @@ import swm.virtuoso.reviewservice.domain.DiscussionComment
 @Tag(name = "Discussion Comment", description = "Discussion Comment API")
 class DiscussionCommentController(
     val discussionCommentUseCase: DiscussionCommentUseCase,
+    val discussionFileUseCase: DiscussionFileUseCase,
     val discussionReactionUseCase: DiscussionReactionUseCase
 ) {
 
@@ -63,6 +65,10 @@ class DiscussionCommentController(
     ): DiscussionCommentResponse {
         val discussionComment = discussionCommentUseCase.getCommentById(id)
         val discussionCommentReactions = discussionReactionUseCase.getDiscussionCommentReactions(id)
+        if (discussionComment.codeId != null) {
+            val filePath = discussionFileUseCase.getDiscussionFilePathByCommentId(discussionComment.codeId)
+            return DiscussionCommentResponse.fromDiscussionComment(discussionComment, discussionCommentReactions, filePath)
+        }
         return DiscussionCommentResponse.fromDiscussionComment(discussionComment, discussionCommentReactions)
     }
 

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionCommentResponse.kt
@@ -8,6 +8,7 @@ data class DiscussionCommentResponse(
     val posterId: Long,
     val groupId: Long?,
     val discussionId: Long,
+    val filePath: String?,
     val codeId: Long?,
     val scope: String,
     val startLine: Int?,
@@ -20,7 +21,8 @@ data class DiscussionCommentResponse(
     companion object {
         fun fromDiscussionComment(
             discussionComment: DiscussionComment,
-            reactions: List<DiscussionReaction>
+            reactions: List<DiscussionReaction>,
+            filePath: String? = null,
         ): DiscussionCommentResponse {
             return DiscussionCommentResponse(
                 id = discussionComment.id!!,
@@ -34,7 +36,8 @@ data class DiscussionCommentResponse(
                 createdUnix = discussionComment.createdUnix,
                 updatedUnix = discussionComment.updatedUnix,
                 codeId = discussionComment.codeId,
-                discussionId = discussionComment.discussionId
+                discussionId = discussionComment.discussionId,
+                filePath = filePath,
             )
         }
     }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionFileUseCase.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionFileUseCase.kt
@@ -6,4 +6,5 @@ import swm.virtuoso.reviewservice.domain.ExtractedLine
 public interface DiscussionFileUseCase {
     fun getDiscussionContents(discussionId: Long): DiscussionContentResponse
     fun extractLinesWithNumbers(target: String, startLine: Int, endLine: Int): List<ExtractedLine>
+    fun getDiscussionFilePathByCommentId(commentId: Long): String
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionFileService.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionFileService.kt
@@ -41,6 +41,11 @@ class DiscussionFileService(
         return result
     }
 
+    override fun getDiscussionFilePathByCommentId(commentId : Long): String {
+        val code = discussionCodePort.findDiscussionCodeById(commentId)
+        return code.filePath
+    }
+
     private fun extractGlobalComments(
         comments: List<DiscussionComment>,
         reactions: List<DiscussionReaction>


### PR DESCRIPTION
### 작업내용
- DiscussionResponse에 filePath 필드 추가
- 디스커션의 코멘트 Id를 통해 filePath 가져오는 로직 추가

### 변경사항

### 비고
Gitea에서 특정 git 파일의 내용을 가져오기 위해선 repository의 path와 filePath가 필요하기 때문에 해당 부분을 추가함.
추후에 아마 관련 api를 수정하게 되면 삭제해도 될듯 싶음.