### PR TITLE
fix: DiscussionDetailController getWatch 수정

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -15,11 +15,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ChangeDiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DeleteReactionRequest
-import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.PostReactionRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionContentResponse
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionWatchResponse
@@ -154,9 +154,9 @@ class DiscussionDetailController(
         ]
     )
     fun getWatch(
-        @Valid @RequestBody
-        request: DiscussionWatchRequest
+        @RequestParam discussionId: Long,
+        @RequestParam userId: Long
     ): DiscussionWatchResponse {
-        return discussionWatchUseCase.getDiscussionWatch(request)
+        return discussionWatchUseCase.getDiscussionWatch(userId, discussionId)
     }
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -134,7 +134,7 @@ class DiscussionDetailController(
         @Valid @RequestBody
         request: ChangeDiscussionWatchRequest
     ): Boolean {
-        if (request.id == null) {
+        if (request.id == -1L) {
             return discussionWatchUseCase.createWatchStatus(request)
         }
 

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/ChangeDiscussionWatchRequest.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/request/ChangeDiscussionWatchRequest.kt
@@ -3,11 +3,11 @@ package swm.virtuoso.reviewservice.adapter.`in`.web.dto.request
 import jakarta.validation.constraints.NotNull
 
 data class ChangeDiscussionWatchRequest(
-
-    val id: Long? = null,
-    @field:NotNull
+    @field:NotNull(message = "id not found")
+    val id: Long,
+    @field:NotNull(message = "userId not found")
     val userId: Long,
-    @field:NotNull
+    @field:NotNull(message = "discussionId not found")
     val discussionId: Long
 
 )

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionWatchResponse.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/dto/response/DiscussionWatchResponse.kt
@@ -1,6 +1,6 @@
 package swm.virtuoso.reviewservice.adapter.`in`.web.dto.response
 
 data class DiscussionWatchResponse(
-    val id: Long,
+    val id: Long?,
     val isWatching: Boolean
 )

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/DiscussionWatchPersistenceAdapter.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/DiscussionWatchPersistenceAdapter.kt
@@ -24,19 +24,12 @@ class DiscussionWatchPersistenceAdapter(
         )
     }
 
-    override fun findByUserIdAndDiscussionId(userId: Long, discussionId: Long): DiscussionWatch {
-        val search = discussionWatchRepository.findByUserIdAndDiscussionId(userId, discussionId)
+    override fun findByUserIdAndDiscussionId(userId: Long, discussionId: Long): DiscussionWatch? {
+        val entity = discussionWatchRepository.findByUserIdAndDiscussionId(userId, discussionId).orElseGet(null)
 
-        if (search.isEmpty) {
-            return DiscussionWatch(
-                id = null,
-                userId = userId,
-                discussionId = discussionId,
-                isWatching = false
-            )
+        if (entity == null) {
+            return null
         }
-
-        val entity = search.get()
 
         return DiscussionWatch(
             id = entity.id!!,

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/DiscussionWatchPersistenceAdapter.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/out/persistence/DiscussionWatchPersistenceAdapter.kt
@@ -25,9 +25,18 @@ class DiscussionWatchPersistenceAdapter(
     }
 
     override fun findByUserIdAndDiscussionId(userId: Long, discussionId: Long): DiscussionWatch {
-        val entity = discussionWatchRepository.findByUserIdAndDiscussionId(userId, discussionId).orElseThrow {
-            throw IllegalArgumentException("No discussion watch found for userid: $userId, discussion id: $discussionId")
+        val search = discussionWatchRepository.findByUserIdAndDiscussionId(userId, discussionId)
+
+        if (search.isEmpty) {
+            return DiscussionWatch(
+                id = null,
+                userId = userId,
+                discussionId = discussionId,
+                isWatching = false
+            )
         }
+
+        val entity = search.get()
 
         return DiscussionWatch(
             id = entity.id!!,

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionWatchUseCase.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionWatchUseCase.kt
@@ -6,6 +6,6 @@ import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionWatchR
 
 interface DiscussionWatchUseCase {
     fun changeWatchStatus(changeDiscussionWatchRequest: ChangeDiscussionWatchRequest): Boolean
-    fun getDiscussionWatch(changeDiscussionWatchRequest: DiscussionWatchRequest): DiscussionWatchResponse
+    fun getDiscussionWatch(userId: Long, discussionId: Long): DiscussionWatchResponse
     fun createWatchStatus(changeDiscussionWatchRequest: ChangeDiscussionWatchRequest): Boolean
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionWatchUseCase.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/port/in/DiscussionWatchUseCase.kt
@@ -1,7 +1,6 @@
 package swm.virtuoso.reviewservice.application.port.`in`
 
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ChangeDiscussionWatchRequest
-import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionWatchResponse
 
 interface DiscussionWatchUseCase {

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/port/out/DiscussionWatchPort.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/port/out/DiscussionWatchPort.kt
@@ -5,7 +5,7 @@ import swm.virtuoso.reviewservice.domain.DiscussionWatch
 interface DiscussionWatchPort {
 
     fun findById(id: Long): DiscussionWatch
-    fun findByUserIdAndDiscussionId(userId: Long, discussionId: Long): DiscussionWatch
+    fun findByUserIdAndDiscussionId(userId: Long, discussionId: Long): DiscussionWatch?
     fun checkWatchDuplication(userId: Long, discussionId: Long)
     fun save(userId: Long, discussionId: Long)
     fun update(discussionWatch: DiscussionWatch)

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
@@ -30,15 +30,17 @@ class DiscussionWatchService(
         return false
     }
 
-    override fun getDiscussionWatch(changeDiscussionWatchRequest: DiscussionWatchRequest): DiscussionWatchResponse {
+    override fun getDiscussionWatch(userId: Long, discussionId: Long): DiscussionWatchResponse {
         val discussionWatch = discussionWatchPort.findByUserIdAndDiscussionId(
-            userId = changeDiscussionWatchRequest.userId,
-            changeDiscussionWatchRequest.discussionId
+            userId = userId,
+            discussionId = discussionId
         )
+
 
         return DiscussionWatchResponse(
             id = discussionWatch.id,
             isWatching = discussionWatch.isWatching
         )
+
     }
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
@@ -36,6 +36,12 @@ class DiscussionWatchService(
             discussionId = discussionId
         )
 
+        if (discussionWatch == null) {
+            return DiscussionWatchResponse(
+                id = -1L,
+                isWatching = false
+            )
+        }
 
         return DiscussionWatchResponse(
             id = discussionWatch.id,

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionWatchService.kt
@@ -2,7 +2,6 @@ package swm.virtuoso.reviewservice.application.service
 
 import org.springframework.stereotype.Service
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ChangeDiscussionWatchRequest
-import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionWatchResponse
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionWatchUseCase
 import swm.virtuoso.reviewservice.application.port.out.DiscussionWatchPort
@@ -13,7 +12,7 @@ class DiscussionWatchService(
 ) : DiscussionWatchUseCase {
 
     override fun changeWatchStatus(changeDiscussionWatchRequest: ChangeDiscussionWatchRequest): Boolean {
-        val discussionWatch = discussionWatchPort.findById(changeDiscussionWatchRequest.id!!)
+        val discussionWatch = discussionWatchPort.findById(changeDiscussionWatchRequest.id)
         discussionWatch.changeWatchingStatus()
         discussionWatchPort.update(discussionWatch)
 
@@ -47,6 +46,5 @@ class DiscussionWatchService(
             id = discussionWatch.id,
             isWatching = discussionWatch.isWatching
         )
-
     }
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/domain/DiscussionWatch.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/domain/DiscussionWatch.kt
@@ -1,7 +1,7 @@
 package swm.virtuoso.reviewservice.domain
 
 data class DiscussionWatch(
-    val id: Long,
+    val id: Long?,
     val userId: Long,
     val discussionId: Long,
     var isWatching: Boolean

--- a/src/main/kotlin/swm/virtuoso/reviewservice/domain/DiscussionWatch.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/domain/DiscussionWatch.kt
@@ -1,7 +1,7 @@
 package swm.virtuoso.reviewservice.domain
 
 data class DiscussionWatch(
-    val id: Long?,
+    val id: Long,
     val userId: Long,
     val discussionId: Long,
     var isWatching: Boolean


### PR DESCRIPTION
### 변경사항

1. getWatch 메소드의 ResponseBody로 받는 방식을 QueryString으로 받는 방식으로 변경

2. userId와 discussionId와 일치하는 DiscussionWatch가 없는 경우에는 null을 가진 DiscussionWatchResponse를 반환하도록 변경

기존에는 getWatch를 했을 때 해당하는 userId와 discussionId와 일치하는 DiscussionWatch가 없으면 exception을 던지는 걸로 구현되어 있었는데 이러면 기존 로직 상으론 유저가 해당 디스커션을 한 번도 구독한 적이 없을 땐 항상 exception을 던지게 됨.
