### PR TITLE
[VIR-208]feat: Discussion Comment의 Reactions만 가져오는 엔드포인트 추가

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -18,6 +18,7 @@ import swm.virtuoso.reviewservice.adapter.`in`.web.dto.response.DiscussionWatchR
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionFileUseCase
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionReactionUseCase
 import swm.virtuoso.reviewservice.application.port.`in`.DiscussionWatchUseCase
+import swm.virtuoso.reviewservice.common.annotation.SwaggerResponse
 import swm.virtuoso.reviewservice.common.exception.ErrorResponse
 import swm.virtuoso.reviewservice.domain.DiscussionReaction
 import swm.virtuoso.reviewservice.domain.ExtractedLine
@@ -63,20 +64,8 @@ class DiscussionDetailController(
     @GetMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "give reaction", description = "게시글 혹은 코멘트에 반응 추가")
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "204",
-                description = "반응 추가 성공",
-                content = [Content(schema = Schema(implementation = Long::class))]
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "디스커션 혹은 코멘트 정보를 찾을 수 없음",
-                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
-            )
-        ]
-    )
+    @SwaggerResponse(responseStatus =  "204", description = "반응 추가 성공", Long::class)
+    @SwaggerResponse(responseStatus =  "404", description = "디스커션 혹은 코멘트 정보를 찾을 수 없음", ErrorResponse::class)
     fun getReaction(
         @RequestParam commentId: Long
     ): List<DiscussionReaction> {

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -8,15 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ChangeDiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DeleteReactionRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DiscussionWatchRequest
@@ -67,6 +59,30 @@ class DiscussionDetailController(
     ): DiscussionContentResponse {
         return discussionFileUseCase.getDiscussionContents(discussionId)
     }
+
+    @GetMapping("/reaction")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "give reaction", description = "게시글 혹은 코멘트에 반응 추가")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "반응 추가 성공",
+                content = [Content(schema = Schema(implementation = Long::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "디스커션 혹은 코멘트 정보를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun getReaction(
+        @RequestParam commentId: Long
+    ): List<DiscussionReaction> {
+        return discussionReactionUseCase.getDiscussionCommentReactions(commentId)
+    }
+
 
     @PostMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -8,7 +8,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.ChangeDiscussionWatchRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DeleteReactionRequest
 import swm.virtuoso.reviewservice.adapter.`in`.web.dto.request.DiscussionWatchRequest
@@ -64,14 +73,13 @@ class DiscussionDetailController(
     @GetMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "give reaction", description = "게시글 혹은 코멘트에 반응 추가")
-    @SwaggerResponse(responseStatus =  "204", description = "반응 추가 성공", Long::class)
-    @SwaggerResponse(responseStatus =  "404", description = "디스커션 혹은 코멘트 정보를 찾을 수 없음", ErrorResponse::class)
+    @SwaggerResponse(responseStatus = "204", description = "반응 추가 성공", Long::class)
+    @SwaggerResponse(responseStatus = "404", description = "디스커션 혹은 코멘트 정보를 찾을 수 없음", ErrorResponse::class)
     fun getReaction(
         @RequestParam commentId: Long
     ): List<DiscussionReaction> {
         return discussionReactionUseCase.getDiscussionCommentReactions(commentId)
     }
-
 
     @PostMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)


### PR DESCRIPTION
https://github.com/SWM-Codection/gitea/pull/128와 연계된 PR입니다.

### 변경사항
1.Discussion Comment의 Reactions만 가져오는 엔드포인트 추가
- 기존에는 반응을 삭제/추가 하면 DiscussionContent를 가져오고 또 거기서 GlobalComment를 찾아서 reactions을 갱신하였습니다. 이게 모양새도 그렇고 전역코멘트에만 유효하고 파일 코멘트에는 유효하지 않아서 새롭게 엔드포인트를 추가했습니다.

### 비고
개인적으로는 그냥 giveReaction과 removeReaction 메소드의 반환값을 바꿔서 해결하는 게 좋아 보이긴 하는데 어떻게 생각하시난지 궁금합니당. 