### PR TITLE
[VIR-210] 디스커션 codeId로 filePath를 직접 가져오는 엔드포인트 추가

### DIFF
--- a/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/adapter/in/web/controller/DiscussionDetailController.kt
@@ -64,14 +64,13 @@ class DiscussionDetailController(
     @GetMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "give reaction", description = "게시글 혹은 코멘트에 반응 추가")
-    @SwaggerResponse(responseStatus =  "204", description = "반응 추가 성공", Long::class)
-    @SwaggerResponse(responseStatus =  "404", description = "디스커션 혹은 코멘트 정보를 찾을 수 없음", ErrorResponse::class)
+    @SwaggerResponse(responseStatus = "204", description = "반응 추가 성공", Long::class)
+    @SwaggerResponse(responseStatus = "404", description = "디스커션 혹은 코멘트 정보를 찾을 수 없음", ErrorResponse::class)
     fun getReaction(
         @RequestParam commentId: Long
     ): List<DiscussionReaction> {
         return discussionReactionUseCase.getDiscussionCommentReactions(commentId)
     }
-
 
     @PostMapping("/reaction")
     @ResponseStatus(HttpStatus.CREATED)
@@ -163,5 +162,16 @@ class DiscussionDetailController(
         request: DiscussionWatchRequest
     ): DiscussionWatchResponse {
         return discussionWatchUseCase.getDiscussionWatch(request)
+    }
+
+    @GetMapping("/code")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "get codeBlock", description = "코드 블록 가져오기")
+    @SwaggerResponse("200", "가져오기 성공", String::class)
+    fun getFilePath(
+        @RequestParam
+        codeId: Long
+    ): String {
+        return discussionFileUseCase.getDiscussionFilePathByCommentId(codeId)
     }
 }

--- a/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionFileService.kt
+++ b/src/main/kotlin/swm/virtuoso/reviewservice/application/service/DiscussionFileService.kt
@@ -41,8 +41,8 @@ class DiscussionFileService(
         return result
     }
 
-    override fun getDiscussionFilePathByCommentId(commentId: Long): String {
-        val code = discussionCodePort.findDiscussionCodeById(commentId)
+    override fun getDiscussionFilePathByCommentId(codeId: Long): String {
+        val code = discussionCodePort.findDiscussionCodeById(codeId)
         return code.filePath
     }
 


### PR DESCRIPTION
###변경사항
codeId로 filePath만 가져올 수 있도록 일단은 엔드포인트 추가했습니다. 추후에 리팩토링 할 때는 codeId로 code를 가져올 수 있는 엔드포인트로 바꿀 것 같습니당.
